### PR TITLE
Implement `techcity broadcast` for a console channel

### DIFF
--- a/data/broadcasts/5MRj8MvC.yaml
+++ b/data/broadcasts/5MRj8MvC.yaml
@@ -1,0 +1,9 @@
+broadcasts:
+- scheduled_for: 2024-03-14 23:00:00+00:00
+  sent_on: null
+- scheduled_for: 2024-03-20 23:00:00+00:00
+  sent_on: null
+event_id: 5MRj8MvC
+event_start_at: 2024-03-21 23:00:00+00:00
+status: !!python/object/apply:techcity.models.BroadcastScheduleStatus
+- pending

--- a/data/broadcasts/jSnulklL.yaml
+++ b/data/broadcasts/jSnulklL.yaml
@@ -1,9 +1,7 @@
 broadcasts:
-- scheduled_for: 2024-03-09 14:00:00+00:00
-  sent_on: null
-- scheduled_for: 2024-03-15 14:00:00+00:00
+- scheduled_for: 2024-03-15 16:00:00+00:00
   sent_on: null
 event_id: jSnulklL
-event_start_at: 2024-03-16 14:00:00+00:00
+event_start_at: 2024-03-16 16:00:00+00:00
 status: !!python/object/apply:techcity.models.BroadcastScheduleStatus
 - pending

--- a/data/broadcasts/lIvIL63q.yaml
+++ b/data/broadcasts/lIvIL63q.yaml
@@ -2,4 +2,4 @@ broadcasts: []
 event_id: lIvIL63q
 event_start_at: 2024-03-05 05:00:00+00:00
 status: !!python/object/apply:techcity.models.BroadcastScheduleStatus
-- pending
+- done

--- a/data/broadcasts/ljrIqpCl.yaml
+++ b/data/broadcasts/ljrIqpCl.yaml
@@ -1,6 +1,6 @@
 broadcasts:
 - scheduled_for: 2024-03-09 16:00:00+00:00
-  sent_on: null
+  sent_on: 2024-03-11 05:40:02.496580+00:00
 - scheduled_for: 2024-03-15 16:00:00+00:00
   sent_on: null
 event_id: ljrIqpCl

--- a/data/broadcasts/qbCcTotj.yaml
+++ b/data/broadcasts/qbCcTotj.yaml
@@ -1,6 +1,6 @@
 broadcasts:
 - scheduled_for: 2024-03-10 17:00:00+00:00
-  sent_on: null
+  sent_on: 2024-03-11 05:40:02.496580+00:00
 - scheduled_for: 2024-03-17 17:00:00+00:00
   sent_on: null
 - scheduled_for: 2024-03-23 17:00:00+00:00

--- a/data/events/aws-frederick/4IRdahxT.yaml
+++ b/data/events/aws-frederick/4IRdahxT.yaml
@@ -8,7 +8,8 @@ extensions:
     id: '299696348'
 group_slug: aws-frederick
 id: 4IRdahxT
-joint_with: []
+joint_with:
+- 5MRj8MvC
 kind: !!python/object/apply:techcity.models.EventKind
 - unspecified
 link: https://www.meetup.com/awsfrederick/events/299696348/

--- a/data/events/aws-frederick/fz8G8u1V.yaml
+++ b/data/events/aws-frederick/fz8G8u1V.yaml
@@ -18,6 +18,7 @@ id: fz8G8u1V
 joint_with:
 - JdM8oXXI
 - M3UctGAY
+- jSnulklL
 - ljrIqpCl
 kind: !!python/object/apply:techcity.models.EventKind
 - unspecified

--- a/data/events/frederick-code-and-coffee/5MRj8MvC.yaml
+++ b/data/events/frederick-code-and-coffee/5MRj8MvC.yaml
@@ -1,0 +1,31 @@
+description: "<p>\U0001F31F Code and Coffee: After Dark \U0001F31F</p> <p>Join us\
+  \ for an evening of talk, networking, and craft beer at a special crossover collaboration\
+  \ with [AWS Frederick](<a href=\"https://www.meetup.com/awsfrederick/\" class=\"\
+  linkified\">https://www.meetup.com/awsfrederick/</a>)!</p> <p>Unwind after a long\
+  \ day and delve into discussions about the latest trends, tools, and techniques\
+  \ in software development and cloud computing. Whether you're a seasoned coder,\
+  \ a curious beginner, or simply interested in the tech (or beer) scene, this event\
+  \ offers something for you.</p> "
+description_type: !!python/object/apply:techcity.models.EventDescriptionType
+- html
+end_at: 2024-03-22 01:00:00+00:00
+extensions:
+  meetup:
+    id: '298848273'
+group_slug: frederick-code-and-coffee
+id: 5MRj8MvC
+joint_with:
+- 4IRdahxT
+kind: !!python/object/apply:techcity.models.EventKind
+- unspecified
+link: https://www.meetup.com/frederick-code-and-coffee/events/298848273/
+name: 'Frederick Code and Coffee: After Dark - Featuring AWS Frederick'
+start_at: 2024-03-21 23:00:00+00:00
+teaser: null
+venue:
+  address: 8411 Broadband Drive k
+  city: Frederick
+  lat: 39.44013595581055
+  lon: -77.38105010986328
+  state: MD
+  zip: '21701'

--- a/data/events/frederick-open-source/M3UctGAY.yaml
+++ b/data/events/frederick-open-source/M3UctGAY.yaml
@@ -18,6 +18,7 @@ id: M3UctGAY
 joint_with:
 - JdM8oXXI
 - fz8G8u1V
+- jSnulklL
 - ljrIqpCl
 kind: !!python/object/apply:techcity.models.EventKind
 - unspecified

--- a/data/events/frederick-web-tech/JdM8oXXI.yaml
+++ b/data/events/frederick-web-tech/JdM8oXXI.yaml
@@ -18,6 +18,7 @@ id: JdM8oXXI
 joint_with:
 - M3UctGAY
 - fz8G8u1V
+- jSnulklL
 - ljrIqpCl
 kind: !!python/object/apply:techcity.models.EventKind
 - unspecified

--- a/data/events/python-frederick/ljrIqpCl.yaml
+++ b/data/events/python-frederick/ljrIqpCl.yaml
@@ -22,6 +22,7 @@ joint_with:
 - JdM8oXXI
 - M3UctGAY
 - fz8G8u1V
+- jSnulklL
 kind: !!python/object/apply:techcity.models.EventKind
 - unspecified
 link: https://www.meetup.com/python-frederick/events/dzjrjtygcfbvb/

--- a/data/events/wordpress-frederick/jSnulklL.yaml
+++ b/data/events/wordpress-frederick/jSnulklL.yaml
@@ -17,24 +17,27 @@ description: "<p>Do you want to work on technology with other tech people in the
   \ href=\"https://www.meetup.com/wordpress-frederick\" class=\"linkified\">https://www.meetup.com/wordpress-frederick</a>)</p> "
 description_type: !!python/object/apply:techcity.models.EventDescriptionType
 - html
-end_at: 2024-03-16 16:00:00+00:00
+end_at: 2024-03-16 18:00:00+00:00
 extensions:
   meetup:
     id: ctjjctygcfbvb
 group_slug: wordpress-frederick
 id: jSnulklL
 joint_with:
-- S6fFPiuL
+- JdM8oXXI
+- M3UctGAY
+- fz8G8u1V
+- ljrIqpCl
 kind: !!python/object/apply:techcity.models.EventKind
 - unspecified
 link: https://www.meetup.com/wordpress-frederick/events/ctjjctygcfbvb/
 name: Frederick Tech Open Workshop - 3rd Saturday
-start_at: 2024-03-16 14:00:00+00:00
+start_at: 2024-03-16 16:00:00+00:00
 teaser: null
 venue:
-  address: 118 N Market St
+  address: 50 Citizen's Way
   city: Frederick
-  lat: 39.415828704833984
-  lon: -77.41044616699219
+  lat: 39.4128532409668
+  lon: -77.4121322631836
   state: MD
   zip: '21701'

--- a/docs/techcity/channels.md
+++ b/docs/techcity/channels.md
@@ -5,6 +5,11 @@ like Discord or X.
 This page documents the available channels and how to configure the channel
 within `techcity.toml`.
 
+## Console
+
+This basic channel is designed to output broadcast information to the terminal output.
+The channel is meant mostly for debugging purposes.
+
 ## Discord
 
 TODO: Create and document the Discord broadcasting channel.

--- a/docs/techcity/channels.md
+++ b/docs/techcity/channels.md
@@ -1,0 +1,10 @@
+# Channels
+
+Channels are where techcity can send outbound information to other services
+like Discord or X.
+This page documents the available channels and how to configure the channel
+within `techcity.toml`.
+
+## Discord
+
+TODO: Create and document the Discord broadcasting channel.

--- a/docs/techcity/services.md
+++ b/docs/techcity/services.md
@@ -27,6 +27,27 @@ on this page.
 As the system grows,
 we may wish to split the catalog up.
 
+### Broadcaster
+
+The broadcaster service has the job of sending out information about events
+to configured channels.
+The goal of this service is to raise awareness of events by providing periodic
+reminders to people on a set schedule.
+These regular notifications can be sent to various channels of interest
+like Discord or X.
+
+The broadcaster service builds broadcast schedules based on event publishing events.
+The broadcast schedules are flushed whenever a broadcast trigger is invoked
+by the `techcity broadcast` command.
+When the trigger occurs,
+the broadcaster scans for pending schedules and send events to a channel
+if a broadcast's scheduled time is in the past.
+This command is designed to be incorporated into a cron schedule
+to send out broadcast messages reguarly.
+
+To learn about the available channels and their configuration,
+see the [Channels documentation](channels.md).
+
 ### Builder
 
 The builder service builds the content of the site.

--- a/techcity/cli.py
+++ b/techcity/cli.py
@@ -33,7 +33,7 @@ def initialize(ctx: typer.Context):
     events_service = EventsService()
     groups_service = GroupsService()
     services = [
-        Broadcaster(),
+        Broadcaster(events_gateway),
         Builder(events_gateway, groups_gateway),
         events_service,
         Fetcher(pubsub, groups_gateway),

--- a/techcity/models.py
+++ b/techcity/models.py
@@ -181,3 +181,9 @@ class BroadcastSchedule(BaseModel):
     # if an event's schedule time is moved from when the schedule is created.
     event_start_at: datetime
     broadcasts: list[Broadcast]
+
+
+class BroadcastScheduleListFilterOptions(BaseModel):
+    """Options to use as filters when listing broadcast schedules"""
+
+    status: BroadcastScheduleStatus | None = None

--- a/techcity/services/broadcaster/channel.py
+++ b/techcity/services/broadcaster/channel.py
@@ -1,0 +1,17 @@
+from techcity.models import Event
+
+
+class Channel:
+    """A channel represents a method of sharing information to others.
+
+    For instance, events could be broadcast to the channels of Discord, X,
+    or Facebook. Channels are solely responsible for sending information
+    to these external services.
+    """
+
+    def send(self, event: Event) -> bool:
+        """Send information about an event via this channel to an external service.
+
+        The channel should report back if the send was successful via the return.
+        """
+        raise NotImplementedError()

--- a/techcity/services/broadcaster/channels/console.py
+++ b/techcity/services/broadcaster/channels/console.py
@@ -1,0 +1,10 @@
+from techcity.models import Event
+from techcity.services.broadcaster.channel import Channel
+
+
+class ConsoleChannel(Channel):
+    """A console channel to broadcast on the terminal output."""
+
+    def send(self, event: Event) -> bool:
+        print(f"Broadcasting {event.id}")
+        return True

--- a/techcity/services/broadcaster/channels/memory.py
+++ b/techcity/services/broadcaster/channels/memory.py
@@ -1,0 +1,13 @@
+from techcity.models import Event
+from techcity.services.broadcaster.channel import Channel
+
+
+class MemoryChannel(Channel):
+    """An in-memory channel that can be used for testing."""
+
+    def __init__(self):
+        self.events_sent = []
+
+    def send(self, event: Event) -> bool:
+        self.events_sent.append(event)
+        return True

--- a/techcity/services/broadcaster/repository.py
+++ b/techcity/services/broadcaster/repository.py
@@ -28,6 +28,9 @@ class BroadcastRepository:
 
     def create(self, schedule: BroadcastSchedule) -> BroadcastSchedule:
         """Persist a broadcast schedule."""
+        return self._save(schedule)
+
+    def _save(self, schedule: BroadcastSchedule) -> BroadcastSchedule:
         schedule_dict = schedule.model_dump()
         outpath = self.broadcasts_path / f"{schedule.event_id}.yaml"
         with open(outpath, "w") as f:
@@ -54,3 +57,11 @@ class BroadcastRepository:
                 if schedule.status == options.status
             ]
         return self.schedules_by_id.values()
+
+    def update(self, schedule: BroadcastSchedule) -> BroadcastSchedule:
+        """Update a broadcast schedule.
+
+        This has the same implementation as `create`, but is kept as a separate
+        method in case needs diverge.
+        """
+        return self._save(schedule)

--- a/techcity/services/broadcaster/repository.py
+++ b/techcity/services/broadcaster/repository.py
@@ -1,9 +1,10 @@
+from collections.abc import Iterable
 from pathlib import Path
 
 import yaml
 
 from techcity import constants
-from techcity.models import BroadcastSchedule
+from techcity.models import BroadcastSchedule, BroadcastScheduleListFilterOptions
 
 
 class BroadcastRepository:
@@ -31,6 +32,8 @@ class BroadcastRepository:
         outpath = self.broadcasts_path / f"{schedule.event_id}.yaml"
         with open(outpath, "w") as f:
             f.write(yaml.dump(schedule_dict, sort_keys=True))
+
+        self.schedules_by_id[schedule.event_id] = schedule
         return schedule
 
     def get(self, event_id: str) -> BroadcastSchedule | None:
@@ -39,3 +42,15 @@ class BroadcastRepository:
         The event ID serves as the primary key.
         """
         return self.schedules_by_id.get(event_id)
+
+    def list(
+        self, options: BroadcastScheduleListFilterOptions
+    ) -> Iterable[BroadcastSchedule]:
+        """Get a list of broadcast schedules."""
+        if options.status is not None:
+            return [
+                schedule
+                for schedule in self.schedules_by_id.values()
+                if schedule.status == options.status
+            ]
+        return self.schedules_by_id.values()

--- a/techcity/services/broadcaster/service.py
+++ b/techcity/services/broadcaster/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from datetime import timedelta
 
-from techcity.events import EventPublished
+from techcity.events import BroadcastTriggered, EventPublished
 from techcity.models import Broadcast, BroadcastSchedule, Event
 from techcity.service import Service
 from techcity.services.broadcaster.channel import Channel
@@ -33,8 +33,14 @@ class Broadcaster(Service):
 
     def dispatch(self, event) -> None:
         match event:
+            case BroadcastTriggered():
+                self._broadcast()
             case EventPublished():
                 self._schedule(event.event)
+
+    def _broadcast(self):
+        """Broadcast any pending and due broadcasts to the channels."""
+        # TODO: implement this.
 
     def _schedule(self, event: Event) -> None:
         """Set an event's broadcast schedule."""

--- a/techcity/services/broadcaster/service.py
+++ b/techcity/services/broadcaster/service.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from techcity.events import EventPublished
 from techcity.models import Broadcast, BroadcastSchedule, Event
 from techcity.service import Service
+from techcity.services.broadcaster.channel import Channel
 
 from .repository import BroadcastRepository
 
@@ -15,11 +16,20 @@ class Broadcaster(Service):
 
     consumes = [EventPublished]
 
-    def __init__(self, repo: BroadcastRepository | None = None) -> None:
+    def __init__(
+        self,
+        repo: BroadcastRepository | None = None,
+        channels: list[Channel] | None = None,
+    ) -> None:
         if repo is None:
             self.repo = BroadcastRepository()
         else:
             self.repo = repo
+
+        if channels is None:
+            self.channels = []
+        else:
+            self.channels = channels
 
     def dispatch(self, event) -> None:
         match event:

--- a/techcity/services/broadcaster/service.py
+++ b/techcity/services/broadcaster/service.py
@@ -67,7 +67,6 @@ class Broadcaster(Service):
         self, schedule: BroadcastSchedule, now: datetime.datetime
     ) -> None:
         """Scan the schedule for any pending broadcasts and take action."""
-        # TODO: all this behavior is untested.
         changed = False
 
         for broadcast in schedule.broadcasts:
@@ -93,8 +92,7 @@ class Broadcaster(Service):
             changed = True
 
         if changed:
-            pass
-            # TODO: Repo update.
+            self.repo.update(schedule)
 
     def _send_broadcast(self, event: Event) -> None:
         """Send the event broadcast to all the channels."""

--- a/techcity/services/broadcaster/tests/test_channels.py
+++ b/techcity/services/broadcaster/tests/test_channels.py
@@ -1,0 +1,25 @@
+import pytest
+
+from techcity.services.broadcaster.channel import Channel
+from techcity.services.broadcaster.channels.memory import MemoryChannel
+from techcity.testing.factories import EventFactory
+
+
+def test_channel_interface():
+    """A channel expects an implementation of the send interface."""
+    channel = Channel()
+    event = EventFactory.build()
+
+    with pytest.raises(NotImplementedError):
+        channel.send(event)
+
+
+def test_memory_channel():
+    """The in-memory channel captures an sent events."""
+    memory_channel = MemoryChannel()
+    event = EventFactory.build()
+
+    sent = memory_channel.send(event)
+
+    assert sent
+    assert memory_channel.events_sent[0] == event

--- a/techcity/services/broadcaster/tests/test_channels.py
+++ b/techcity/services/broadcaster/tests/test_channels.py
@@ -1,6 +1,7 @@
 import pytest
 
 from techcity.services.broadcaster.channel import Channel
+from techcity.services.broadcaster.channels.console import ConsoleChannel
 from techcity.services.broadcaster.channels.memory import MemoryChannel
 from techcity.testing.factories import EventFactory
 
@@ -15,7 +16,7 @@ def test_channel_interface():
 
 
 def test_memory_channel():
-    """The in-memory channel captures an sent events."""
+    """The in-memory channel captures any sent events."""
     memory_channel = MemoryChannel()
     event = EventFactory.build()
 
@@ -23,3 +24,13 @@ def test_memory_channel():
 
     assert sent
     assert memory_channel.events_sent[0] == event
+
+
+def test_console_channel():
+    """The console channel successfully 'sends' events."""
+    console_channel = ConsoleChannel()
+    event = EventFactory.build()
+
+    sent = console_channel.send(event)
+
+    assert sent

--- a/techcity/services/broadcaster/tests/test_repository.py
+++ b/techcity/services/broadcaster/tests/test_repository.py
@@ -1,0 +1,61 @@
+from techcity.models import BroadcastScheduleListFilterOptions, BroadcastScheduleStatus
+from techcity.services.broadcaster.repository import BroadcastRepository
+from techcity.testing.factories import BroadScheduleFactory
+
+
+def test_ensure_broadcasts_dir(tmp_path):
+    """The repository ensures that the broadcasts data storage area exists."""
+    BroadcastRepository(tmp_path)
+    broadcasts_dir = tmp_path / "broadcasts"
+
+    assert broadcasts_dir.exists()
+
+
+def test_create_stores_data(tmp_path):
+    """A broadcast schedule is persisted to disk and update the index."""
+    repo = BroadcastRepository(tmp_path)
+    schedule = BroadScheduleFactory.build()
+
+    repo.create(schedule)
+
+    schedule_path = tmp_path / "broadcasts" / f"{schedule.event_id}.yaml"
+    assert schedule_path.exists()
+    assert schedule.event_id in repo.schedules_by_id
+
+
+def test_get(tmp_path):
+    """The repo gets a schedule by its ID."""
+    repo = BroadcastRepository(tmp_path)
+    schedule = BroadScheduleFactory.build()
+    repo.create(schedule)
+
+    fetched_schedule = repo.get(schedule.event_id)
+
+    assert fetched_schedule == schedule
+
+
+def test_list_all(tmp_path):
+    """All schedules are returned when there is no filtering."""
+    repo = BroadcastRepository(tmp_path)
+    repo.create(BroadScheduleFactory.build(status=BroadcastScheduleStatus.pending))
+    repo.create(BroadScheduleFactory.build(status=BroadcastScheduleStatus.done))
+
+    schedules = repo.list(BroadcastScheduleListFilterOptions())
+
+    assert len(list(schedules)) == 2
+
+
+def test_list_status(tmp_path):
+    """Schedules matching the status are returned when there is status filtering."""
+    repo = BroadcastRepository(tmp_path)
+    pending_schedule = BroadScheduleFactory.build(
+        status=BroadcastScheduleStatus.pending
+    )
+    repo.create(pending_schedule)
+    repo.create(BroadScheduleFactory.build(status=BroadcastScheduleStatus.done))
+
+    schedules = repo.list(
+        BroadcastScheduleListFilterOptions(status=BroadcastScheduleStatus.pending)
+    )
+
+    assert list(schedules) == [pending_schedule]

--- a/techcity/services/broadcaster/tests/test_repository.py
+++ b/techcity/services/broadcaster/tests/test_repository.py
@@ -12,7 +12,7 @@ def test_ensure_broadcasts_dir(tmp_path):
 
 
 def test_create_stores_data(tmp_path):
-    """A broadcast schedule is persisted to disk and update the index."""
+    """A broadcast schedule is persisted to disk and updates the index."""
     repo = BroadcastRepository(tmp_path)
     schedule = BroadScheduleFactory.build()
 

--- a/techcity/services/broadcaster/tests/test_repository.py
+++ b/techcity/services/broadcaster/tests/test_repository.py
@@ -59,3 +59,17 @@ def test_list_status(tmp_path):
     )
 
     assert list(schedules) == [pending_schedule]
+
+
+def test_update_data(tmp_path):
+    """A broadcast schedule is updated to disk and updates the index."""
+    repo = BroadcastRepository(tmp_path)
+    schedule = BroadScheduleFactory.build(status=BroadcastScheduleStatus.pending)
+    repo.create(schedule)
+    schedule.status = BroadcastScheduleStatus.done
+
+    repo.update(schedule)
+
+    updated_schedule = repo.get(schedule.event_id)
+    assert updated_schedule is not None
+    assert updated_schedule.status == BroadcastScheduleStatus.done

--- a/techcity/services/broadcaster/tests/test_service.py
+++ b/techcity/services/broadcaster/tests/test_service.py
@@ -7,12 +7,14 @@ import time_machine
 from techcity.events import BroadcastTriggered, EventPublished
 from techcity.services.broadcaster.channels.memory import MemoryChannel
 from techcity.services.broadcaster.service import Broadcaster
+from techcity.services.events.gateway import EventsGateway
 from techcity.testing.factories import BroadScheduleFactory, EventFactory
 
 
 def test_default():
     """The default constructor uses a real repository."""
-    service = Broadcaster()
+    events_gateway = EventsGateway()
+    service = Broadcaster(events_gateway)
 
     assert service.repo is not None
 
@@ -20,8 +22,9 @@ def test_default():
 @time_machine.travel(datetime.datetime(2024, 3, 6, tzinfo=datetime.UTC))
 def test_event_published_scheduled():
     """EventPublished sets a broadcast schedule."""
+    events_gateway = EventsGateway()
     repo = mock.Mock()
-    service = Broadcaster(repo)
+    service = Broadcaster(events_gateway, repo)
     start_at = datetime.datetime(2024, 3, 27, 21, tzinfo=datetime.UTC)
     event = EventFactory.build(start_at=start_at)
     event_published = EventPublished(event=event)
@@ -36,8 +39,9 @@ def test_event_published_scheduled():
 @time_machine.travel(datetime.datetime(2024, 3, 6, tzinfo=datetime.UTC))
 def test_update_event_changed():
     """The schedule changes when the event is updated."""
+    events_gateway = EventsGateway()
     repo = mock.Mock()
-    service = Broadcaster(repo)
+    service = Broadcaster(events_gateway, repo)
     start_at = datetime.datetime(2024, 3, 27, 21, tzinfo=datetime.UTC)
     original_event = EventFactory.build(start_at=start_at)
     original_schedule = BroadScheduleFactory.build(
@@ -55,11 +59,12 @@ def test_update_event_changed():
 @pytest.mark.xfail
 def test_broadcasts_event():
     """A pending broadcast is sent on a channel."""
+    events_gateway = EventsGateway()
     # TODO: set up an event and broadcast schedule with an event that needs
     # to broadcast.
     repo = mock.Mock()
     channel = MemoryChannel()
-    service = Broadcaster(repo, channels=[channel])
+    service = Broadcaster(events_gateway, repo, channels=[channel])
     broadcast_triggered = BroadcastTriggered()
 
     service.dispatch(broadcast_triggered)

--- a/techcity/services/broadcaster/tests/test_service.py
+++ b/techcity/services/broadcaster/tests/test_service.py
@@ -1,9 +1,11 @@
 import datetime
 from unittest import mock
 
+import pytest
 import time_machine
 
-from techcity.events import EventPublished
+from techcity.events import BroadcastTriggered, EventPublished
+from techcity.services.broadcaster.channels.memory import MemoryChannel
 from techcity.services.broadcaster.service import Broadcaster
 from techcity.testing.factories import BroadScheduleFactory, EventFactory
 
@@ -48,3 +50,19 @@ def test_update_event_changed():
     service.dispatch(event_published)
 
     assert repo.create.called
+
+
+@pytest.mark.xfail
+def test_broadcasts_event():
+    """A pending broadcast is sent on a channel."""
+    # TODO: set up an event and broadcast schedule with an event that needs
+    # to broadcast.
+    repo = mock.Mock()
+    channel = MemoryChannel()
+    service = Broadcaster(repo, channels=[channel])
+    broadcast_triggered = BroadcastTriggered()
+
+    service.dispatch(broadcast_triggered)
+
+    assert len(channel.events_sent) == 1
+    # TODO: assert that it's the event that we expect.

--- a/techcity/services/events/gateway.py
+++ b/techcity/services/events/gateway.py
@@ -18,6 +18,11 @@ class EventsGateway:
         """Connect to the events service."""
         self._service = service
 
+    def get(self, event_id) -> Event | None:
+        if self._service is None:
+            return None
+        return self._service.get(event_id)
+
     def all(self) -> list[Event]:
         if self._service is None:
             return []

--- a/techcity/services/events/repository.py
+++ b/techcity/services/events/repository.py
@@ -3,16 +3,20 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from datetime import datetime
+from pathlib import Path
 
 import yaml
 
-from techcity.constants import data_path
+from techcity import constants
 from techcity.models import Event, EventListFilterOptions
 
 
 class EventRepository:
-    def __init__(self):
+    def __init__(self, data_path: Path | None = None) -> None:
+        if data_path is None:
+            data_path = constants.data_path
         self.events_path = data_path / "events"
+        self.events_path.mkdir(exist_ok=True)
 
         # Indices
         self.events_by_id: dict[str, Event] = {}
@@ -97,6 +101,10 @@ class EventRepository:
         event_dict = event.model_dump()
         with open(outpath / f"{event.id}.yaml", "w") as f:
             f.write(yaml.dump(event_dict, sort_keys=True))
+
+    def get(self, event_id: str) -> Event | None:
+        """Get an event."""
+        return self.events_by_id.get(event_id)
 
     def list(self, options: EventListFilterOptions) -> Iterable[Event]:
         """Get a list of events."""

--- a/techcity/services/events/service.py
+++ b/techcity/services/events/service.py
@@ -23,6 +23,9 @@ class EventsService(Service):
             case EventPublished():
                 self.repo.create(event.event.model_dump())
 
+    def get(self, event_id: str) -> Event | None:
+        return self.repo.get(event_id)
+
     def list(self, options: EventListFilterOptions) -> list[Event]:
         """Get a list of events."""
         return list(self.repo.list(options))

--- a/techcity/services/events/tests/test_repository.py
+++ b/techcity/services/events/tests/test_repository.py
@@ -1,0 +1,33 @@
+from techcity.services.events.repository import EventRepository
+from techcity.testing.factories import EventFactory
+
+
+def test_ensure_events_dir(tmp_path):
+    """The repository ensures that the events data storage area exists."""
+    EventRepository(tmp_path)
+    events_dir = tmp_path / "events"
+
+    assert events_dir.exists()
+
+
+def test_create_stores_data(tmp_path):
+    """An event is persisted to disk and update the index."""
+    repo = EventRepository(tmp_path)
+    event = EventFactory.build()
+
+    repo.create(event.model_dump())
+
+    event_path = tmp_path / "events" / event.group_slug / f"{event.id}.yaml"
+    assert event_path.exists()
+    assert event.id in repo.events_by_id
+
+
+def test_get(tmp_path):
+    """The repo gets an event by its ID."""
+    repo = EventRepository(tmp_path)
+    event = EventFactory.build()
+    repo.create(event.model_dump())
+
+    fetched_event = repo.get(event.id)
+
+    assert fetched_event == event


### PR DESCRIPTION
Currently, `techcity broadcast` is a noop. This branch will implement the logic that will scan the pending broadcast schedules, send any relevant broadcast, and update broadcast schedule state.

Instead of sending to real channels, the focus on this branch will be on the logic around schedules. This branch defined the expected interface for channels and how to send an event, but the implementation of a Discord broadcast channel will be done in a different branch.

For #43